### PR TITLE
add object registry & ObjectEntity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.alwaysSignOff": true
+}

--- a/pkg/supervisor/object.go
+++ b/pkg/supervisor/object.go
@@ -1,0 +1,29 @@
+package supervisor
+
+import "fmt"
+
+type (
+	ObjectEntity struct {
+		super *Supervisor
+
+		instance Object
+	}
+)
+
+// Instance returns the instance of the Object.
+func (e *ObjectEntity) Instance() Object {
+	return e.instance
+}
+
+// NewObjectEntity creates a new ObjectEntity.
+func (s *Supervisor) NewObjectEntity(kind string) (*ObjectEntity, error) {
+	if _, ok := objectRegistry[kind]; !ok {
+		return nil, fmt.Errorf("object (%s) does not exist", kind)
+	}
+
+	instance := objectRegistry[kind].Clone()
+	return &ObjectEntity{
+		super:    s,
+		instance: instance,
+	}, nil
+}

--- a/pkg/supervisor/registry.go
+++ b/pkg/supervisor/registry.go
@@ -4,14 +4,20 @@ import "fmt"
 
 type (
 	Object interface {
+		// Kind returns the kind of the object.
 		Kind() string
+
+		// Clone returns a copy of the object.
+		Clone() Object
 	}
 )
 
 var (
+	// objectRegistry is the registry of objects.
 	objectRegistry = map[string]Object{}
 )
 
+// Register registers an object.
 func Register(o Object) {
 	_, ok := objectRegistry[o.Kind()]
 	if ok {

--- a/pkg/supervisor/registry.go
+++ b/pkg/supervisor/registry.go
@@ -1,0 +1,21 @@
+package supervisor
+
+import "fmt"
+
+type (
+	Object interface {
+		Kind() string
+	}
+)
+
+var (
+	objectRegistry = map[string]Object{}
+)
+
+func Register(o Object) {
+	_, ok := objectRegistry[o.Kind()]
+	if ok {
+		panic(fmt.Sprintf("object (%s) already exists", o.Kind()))
+	}
+	objectRegistry[o.Kind()] = o
+}

--- a/pkg/supervisor/registry_test.go
+++ b/pkg/supervisor/registry_test.go
@@ -1,0 +1,32 @@
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type (
+	mockObject struct {
+	}
+)
+
+func (m *mockObject) Kind() string {
+	return "mock_object"
+}
+
+func TestRegister(t *testing.T) {
+	assert.NotPanics(
+		t,
+		func() { Register(&mockObject{}) },
+		"panic in Register",
+	)
+	assert.Equal(t, 1, len(objectRegistry))
+	_, ok := objectRegistry["mock_object"]
+	assert.True(t, ok)
+	assert.PanicsWithValue(
+		t,
+		"object (mock_object) already exists",
+		func() { Register(&mockObject{}) },
+	)
+}


### PR DESCRIPTION
Registry 保存了所有运行时创建对象的原型
ObjectEntity 用于描述一个对象并保存一个对象模型